### PR TITLE
Deep-copy lists to prevent mutation of starting data

### DIFF
--- a/historian_hysteria/historian_hysteria.py
+++ b/historian_hysteria/historian_hysteria.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # Import built-ins
+import copy
 import os
 from typing import Iterable
 
@@ -26,14 +27,16 @@ def extract_columns(corpus: str) -> tuple[list, list]:
     return _left_column, _right_column
 
 
-def create_sorted_pairs(first_column: list[int], second_column: list[int]) -> Iterable[tuple[int, int]]:
-    first_column.sort()
-    second_column.sort()
-    return zip(first_column, second_column)
+def create_sorted_pairs(first_column: list[int],
+                        second_column: list[int]
+                       ) -> Iterable[tuple[int, int]]:
+    return zip(sorted(copy.deepcopy(first_column)),
+               sorted(copy.deepcopy(second_column)))
 
 
 def sum_distance_differences(pairs: Iterable[tuple[int, int]]) -> int:
-    return sum(abs(_left_datum - _right_datum) for _left_datum, _right_datum in pairs)
+    return sum(abs(_left_datum - _right_datum)
+               for _left_datum, _right_datum in pairs)
 
 
 contents = read_data_file("distances.txt")
@@ -41,7 +44,6 @@ left_column, right_column = extract_columns(contents)
 sorted_pairs = create_sorted_pairs(left_column, right_column)
 total_difference = sum_distance_differences(sorted_pairs)
 
-print(f"""
-Part 1
-------
-The total difference of distances between lists is equal to {total_difference:,} units.""")
+print("\nPart 1\n------")
+print("The total difference of distances between lists is equal to "
+      f"{total_difference:,} units.")


### PR DESCRIPTION
Lists passed to `create_sorted_pairs()` are now deep-copied instead of being manipulated as-is to ensure the initial data is not mutated.

This commit also features style changes to balance PEP8 line length suggestions with readability.